### PR TITLE
chore: add basic CI

### DIFF
--- a/.github/workflows/build-n-test.yaml
+++ b/.github/workflows/build-n-test.yaml
@@ -1,0 +1,22 @@
+name: Rust
+
+on:
+  push:
+    branches: [ "master" ]
+  pull_request:
+    branches: [ "master", "development", "@*/*" ]
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v3
+    - name: Build
+      run: cargo build --verbose
+    - name: Run tests
+      run: cargo test --verbose


### PR DESCRIPTION
The CI builds & test library.

The CI should be triggered when:

* commit is pushed to `master` branch
* PR is issued against one of `master`, `development` or user-specific (starting with `@<username>/` branches.

Fixes #19 