### PR TITLE
fix: add YAML front matters for issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -1,3 +1,8 @@
+---
+name: Bug report
+about: Use this template to report a bug
+---
+
 # Bug report
 
 ## Description

--- a/.github/ISSUE_TEMPLATE/missing-feature.md
+++ b/.github/ISSUE_TEMPLATE/missing-feature.md
@@ -1,3 +1,8 @@
+---
+name: Feature proposal
+about: Use this template to propose new / missing features
+---
+
 # Missing feature
 
 ## Description


### PR DESCRIPTION
According to [GitHub docs](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/about-issue-and-pull-request-templates#issue-templates) this YAML header is required for issue templates to be valid. Forgot about it earlier.