### PR TITLE
feat: reimplement GA & add some basic genetic operators

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ target/
 
 # algorithms ouput directory
 output/
+*local.*

--- a/src/examples.rs
+++ b/src/examples.rs
@@ -1,6 +1,7 @@
 
 use crate::aco::probe::CsvProbe;
 use crate::aco::AntSystemCfg;
+use crate::ga;
 use crate::ga::*;
 use crate::pso::*;
 use crate::ff::*;
@@ -57,13 +58,13 @@ pub fn ga_example() {
     selection_rate: 0.5,
     generation_upper_bound: 200,
     population_size: 400,
-    fitness_fn: quadratic_function,
+    fitness_fn: quadratic_fn,
     mutation_operator: quadratic_mutation_operator,
     population_factory: quadratic_population_factory,
     eps: 1e-4,
     // probe: Box::new(ga::StdoutProbe{}),
     // probe: Box::new(ga::CsvProbe::new("ga_testing.csv".to_owned())),
     probe: Box::new(crate::ga::JsonProbe::new("ga_testing.json".to_owned())),
-    crossover_operator: quadratic_crossover_operator,
+    crossover_operator: ga::operators::crossover::single_point,
   }).run();
 }

--- a/src/ga.rs
+++ b/src/ga.rs
@@ -2,6 +2,7 @@ mod individual;
 mod probe;
 mod example;
 mod builder;
+mod operators;
 
 pub use individual::Individual;
 pub use probe::{Probe};

--- a/src/ga.rs
+++ b/src/ga.rs
@@ -147,4 +147,16 @@ impl GeneticAlgorithm {
       None
     }
   }
+
+	pub fn run_new(&mut self) -> Option<Individual> {
+		// 1. Create initial random population.
+		// 2. Evaluate fitness for each individual.
+		// 3. Store best individual.
+		// 4. Create mating pool by applying selection operator.
+		// 5. From mating pool create new generation (apply crossover & mutation).
+		// 6. Check for stop condition (Is good enough individual found)? If not goto 2.
+		//
+
+		None
+	}
 }

--- a/src/ga.rs
+++ b/src/ga.rs
@@ -1,10 +1,11 @@
 mod individual;
 mod probe;
-mod example;
-mod builder;
-mod operators;
+pub mod example;
+pub mod builder;
+pub mod operators;
 
 pub use individual::Individual;
+use log::info;
 pub use probe::{Probe};
 pub use probe::stdout_probe::{StdoutProbe};
 pub use probe::json_probe::{JsonProbe};
@@ -18,7 +19,7 @@ use rand::rngs::ThreadRng;
 type Population = Vec<Individual>;
 type FitnessFn = fn(&Individual) -> f64;
 type MutationOperator = fn(&mut Individual) -> Individual;
-type CrossoverOperator = fn(&Individual, &Individual) -> Individual;
+type CrossoverOperator = fn(&Individual, &Individual) -> (Individual, Individual);
 type PopulationGenerator = fn(usize) -> Population;
 
 pub struct GeneticAlgorithmCfg {
@@ -44,7 +45,7 @@ impl Default for GeneticAlgorithmCfg {
         eps: 1e-4,
         fitness_fn: rastrigin_fitness_function,
         mutation_operator: rastrigin_mutation_operator,
-        crossover_operator: rastrigin_crossover_operator,
+        crossover_operator: operators::crossover::single_point,
         population_factory: rastrigin_population_factory,
         probe: Box::new(StdoutProbe{}),
       }
@@ -64,24 +65,6 @@ impl GeneticAlgorithm {
     }
   }
 
-  fn maybe_apply_mutation_operator(&mut self, target: &mut Individual, probability: f64) -> Individual {
-    if self.rng.gen_range(0f64..1f64) < probability {
-      let target_copy = target.clone();
-      let result = (self.config.mutation_operator)(target);
-      self.config.probe.on_mutation(&target_copy, &result);
-      return result;
-    }
-    return target.clone();
-  }
-
-  fn select_individual_from_n_random(&mut self, population: &Vec<Individual>, n: usize) -> Individual {
-    if let Some(selected) = (0..n).map(|_| population[self.rng.gen_range(0..population.len())].clone()).min() {
-      selected
-    } else {
-      unimplemented!()
-    }
-  }
-
 	fn find_best_individual(population: &Population) -> &Individual {
 		debug_assert!(population.len() > 0);
 		let mut best_individual = &population[0];
@@ -93,87 +76,21 @@ impl GeneticAlgorithm {
 		best_individual
 	}
 
-  fn run_old(&mut self) -> Option<Individual> {
-    let mut population = (self.config.population_factory)(self.config.population_size);
-
-    for generation_idx in 0..self.config.generation_upper_bound {
-      self.config.probe.on_iteration_start(generation_idx as usize);
-      let mut new_generation: Vec<Individual> = Vec::with_capacity(self.config.population_size as usize);
-
-      population.iter_mut().for_each(|individual| {
-        individual.fitness = (self.config.fitness_fn)(&individual);
-      });
-
-      // TODO: consider to parametrize this
-      for _ in 0..(self.config.population_size / 2) {
-        let (mut father, mut mother) = (
-            self.select_individual_from_n_random(&population, (self.config.selection_rate * self.config.population_size as f64) as usize),
-            self.select_individual_from_n_random(&population, (self.config.selection_rate * self.config.population_size as f64) as usize)
-        );
-
-        // TODO: possible optimization
-        father = self.maybe_apply_mutation_operator(&mut father, self.config.mutation_rate);
-        mother = self.maybe_apply_mutation_operator(&mut mother, self.config.mutation_rate);
-
-        let child = (self.config.crossover_operator)(&father, &mother);
-        new_generation.push(child);
-        if self.rng.gen_bool(self.config.selection_rate as f64) {
-          new_generation.push(father);
-        } else {
-          new_generation.push(mother);
-        }
-      }
-
-      population = new_generation;
-
-      population.iter_mut().for_each(|individual| {
-        individual.fitness = (self.config.fitness_fn)(&individual);
-      });
-
-      self.config.probe.on_new_generation(&population);
-
-      if let Some(individual) = population.iter().min() {
-        self.config.probe.on_best_fit_in_generation(individual);
-        if (self.config.fitness_fn)(&individual) < self.config.eps {
-          self.config.probe.on_new_best(individual);
-          self.config.probe.on_end();
-          return Option::Some((*individual).clone());
-        }
-      }
-
-      self.config.probe.on_iteration_end(generation_idx as usize);
-    }
-    self.config.probe.on_end();
-    if let Some(individual) = population.iter().min() {
-      if (self.config.fitness_fn)(&individual) < self.config.eps {
-        return Option::Some((*individual).clone());
-      } else {
-        None
-      }
-    } else {
-      None
-    }
-  }
+	fn evaluate_fitness_in_population(&self, population: &mut Population) -> () {
+		for i in 0..population.len() {
+			population[i].fitness = (self.config.fitness_fn)(&population[i]);
+		}
+	}
 
 	pub fn run(&mut self) -> Option<Individual> {
 		// 1. Create initial random population.
 		let mut population = (self.config.population_factory)(self.config.population_size);
 
 		// 2. Evaluate fitness for each individual.
-		let mut best_individual: &Individual = &population[0];
-
-		for individual in population {
-			individual.fitness = (self.config.fitness_fn)(&individual);
-
-			// Note that here we use "<" operator thus minimizing the fitness function.
-			// It is important to make this more generic & document this well.
-			if individual < *best_individual {
-				best_individual = &individual;
-			}
-		}
+		self.evaluate_fitness_in_population(&mut population);
 
 		// 3. Store best individual.
-		// Already calculated at step 2.
+		let best_individual = GeneticAlgorithm::find_best_individual(&population);
 
 		if best_individual.fitness < self.config.eps {
 			return Some(best_individual.to_owned())
@@ -182,16 +99,15 @@ impl GeneticAlgorithm {
 		for generation_no in 0..self.config.generation_upper_bound {
 			println!("Calculating generation {}", generation_no);
 			// 2. Evaluate fitness for each individual.
-			// let mut best_individual: &Individual = &population[0];
 
-			for individual in population {
-				individual.fitness = (self.config.fitness_fn)(&individual);
-			}
+			self.evaluate_fitness_in_population(&mut population);
 
 			// 4. Create mating pool by applying selection operator.
 			// FIXME: This should be taken from config, but as for now, I'm taking it directly
 			// from operators module.
 			let mating_pool: Vec<&Individual> = operators::selection::roulette_wheel(&population, population.len());
+
+			// break;
 
 			// 5. From mating pool create new generation (apply crossover & mutation).
 			let mut children: Population = Vec::with_capacity(self.config.population_size);
@@ -200,11 +116,14 @@ impl GeneticAlgorithm {
 			for i in (0..mating_pool.len()).step_by(2) {
 			// FIXME: This should be taken from config, but as for now, I'm taking it directly
 			// from operators module.
+				println!("Mating pool loop i: {}", i);
 				let crt_children = operators::crossover::single_point(mating_pool[i], mating_pool[i + 1]);
 
 				children.push(crt_children.0);
 				children.push(crt_children.1);
 			}
+
+			// 5.1 Here we should apply the mutations on children?
 
 			// 6. Replacement - merge new generation with old one
 			// TODO
@@ -213,6 +132,7 @@ impl GeneticAlgorithm {
 			population = children;
 
 			// 6. Check for stop condition (Is good enough individual found)? If not goto 2.
+			self.evaluate_fitness_in_population(&mut population);
 			let best_individual = GeneticAlgorithm::find_best_individual(&population);
 			if best_individual.fitness < self.config.eps {
 				return Some(best_individual.to_owned())

--- a/src/ga.rs
+++ b/src/ga.rs
@@ -5,16 +5,12 @@ pub mod builder;
 pub mod operators;
 
 pub use individual::Individual;
-use log::info;
-pub use probe::{Probe};
-pub use probe::stdout_probe::{StdoutProbe};
-pub use probe::json_probe::{JsonProbe};
-pub use probe::csv_probe::{CsvProbe};
-pub use example::{*};
+pub use probe::Probe;
+pub use probe::stdout_probe::StdoutProbe;
+pub use probe::json_probe::JsonProbe;
+pub use probe::csv_probe::CsvProbe;
+pub use example::*;
 pub use builder::*;
-
-use rand::{Rng, thread_rng};
-use rand::rngs::ThreadRng;
 
 type Population = Vec<Individual>;
 type FitnessFn = fn(&Individual) -> f64;

--- a/src/ga.rs
+++ b/src/ga.rs
@@ -54,14 +54,12 @@ impl Default for GeneticAlgorithmCfg {
 
 pub struct GeneticAlgorithm {
   config: GeneticAlgorithmCfg,
-  rng: ThreadRng,
 }
 
 impl GeneticAlgorithm {
   pub fn new(config: GeneticAlgorithmCfg) -> Self {
     GeneticAlgorithm {
       config,
-      rng: thread_rng(),
     }
   }
 
@@ -106,8 +104,6 @@ impl GeneticAlgorithm {
 			// FIXME: This should be taken from config, but as for now, I'm taking it directly
 			// from operators module.
 			let mating_pool: Vec<&Individual> = operators::selection::roulette_wheel(&population, population.len());
-
-			// break;
 
 			// 5. From mating pool create new generation (apply crossover & mutation).
 			let mut children: Population = Vec::with_capacity(self.config.population_size);

--- a/src/ga.rs
+++ b/src/ga.rs
@@ -106,9 +106,8 @@ impl GeneticAlgorithm {
 
 			// FIXME: Do not assume that population size is an even number.
 			for i in (0..mating_pool.len()).step_by(2) {
-			// FIXME: This should be taken from config, but as for now, I'm taking it directly
-			// from operators module.
-				println!("Mating pool loop i: {}", i);
+				// FIXME: This should be taken from config, but as for now, I'm taking it directly
+				// from operators module.
 				let crt_children = operators::crossover::single_point(mating_pool[i], mating_pool[i + 1]);
 
 				children.push(crt_children.0);

--- a/src/ga/builder.rs
+++ b/src/ga/builder.rs
@@ -12,6 +12,12 @@ impl Builder {
     }
   }
 
+	pub fn new_with_config(config: GeneticAlgorithmCfg) -> Self {
+		Builder {
+			config
+		}
+	}
+
   pub fn set_mutation_rate(mut self, mutation_rate: f64) -> Self {
     debug_assert!(mutation_rate >= 0f64 && mutation_rate <= 1f64);
     self.config.mutation_rate = mutation_rate;

--- a/src/ga/builder.rs
+++ b/src/ga/builder.rs
@@ -7,7 +7,7 @@ pub struct Builder {
 
 impl Builder {
   pub fn new() -> Self {
-    Builder { 
+    Builder {
       config: GeneticAlgorithmCfg::default()
     }
   }
@@ -24,13 +24,18 @@ impl Builder {
     self
   }
 
+	pub fn set_eps(mut self, eps: f64) -> Self {
+		self.config.eps = eps;
+		self
+	}
+
   pub fn set_max_generation_count(mut self, max_gen_count: i32) -> Self {
     debug_assert!(max_gen_count >= 1);
     self.config.generation_upper_bound = max_gen_count;
     self
   }
 
-  pub fn set_population_size(mut self, size: i32) -> Self {
+  pub fn set_population_size(mut self, size: usize) -> Self {
     debug_assert!(size > 0);
     self.config.population_size = size;
     self

--- a/src/ga/example.rs
+++ b/src/ga/example.rs
@@ -64,7 +64,8 @@ pub fn quadratic_crossover_operator(father: &Individual, mother: &Individual) ->
   }
 }
 
-pub fn rastrigin_fitness_function(chromosome: &[f64]) -> f64 {
+pub fn rastrigin_fitness_function(individual: &Individual) -> f64 {
+	let chromosome = individual.chromosome;
   return 10_f64 * chromosome.len() as f64 + chromosome.iter().fold(0_f64, |sum, x| {
     sum + x.powi(2) - 10_f64 * (2_f64 * consts::PI * x).cos()
   })
@@ -87,7 +88,7 @@ pub fn rastrigin_mutation_operator(individual: &mut Individual) -> Individual {
   }
 }
 
-pub fn rastrigin_population_factory(population_size: i32) -> Vec<Individual> {
+pub fn rastrigin_population_factory(population_size: usize) -> Vec<Individual> {
   let mut rng = thread_rng();
   let distribution: Uniform<f64> = Uniform::from(-5.12..5.12);
   let mut population: Vec<Individual> = Vec::with_capacity(population_size as usize);

--- a/src/ga/example.rs
+++ b/src/ga/example.rs
@@ -1,13 +1,9 @@
 use std::cmp::min;
-use rand::{random, Rng, thread_rng};
-use rand::rngs::ThreadRng;
+use rand::{Rng, thread_rng};
 use rand::distributions::{Distribution, Uniform};
 use std::f64::consts;
-use log::{warn, info};
 
 use crate::ga::Individual;
-
-use super::individual;
 
 pub fn quadratic_fn(individual: &Individual) -> f64 {
 	individual.chromosome.clone().into_iter().map(|val| val * val).sum()

--- a/src/ga/example.rs
+++ b/src/ga/example.rs
@@ -7,6 +7,12 @@ use log::{warn, info};
 
 use crate::ga::Individual;
 
+use super::individual;
+
+pub fn quadratic_fn(individual: &Individual) -> f64 {
+	individual.chromosome.clone().into_iter().map(|val| val * val).sum()
+}
+
 pub fn quadratic_function(chromosome: &[f64]) -> f64 {
   return chromosome[0] * chromosome[0]; // + 3 as f64 * chromosome[0];
 }
@@ -27,17 +33,27 @@ pub fn quadratic_mutation_operator(individual: &mut Individual) -> Individual {
   }
 }
 
-pub fn quadratic_population_factory(population_size: i32) -> Vec<Individual> {
-  let mut rng = thread_rng();
-  let distribution: Uniform<f64> = Uniform::from(-10_f64..10_f64);
+pub fn point_generator(restrictions: &Vec<(f64, f64)>) -> Vec<f64> {
+	assert!(restrictions.len() > 0);
 
-  let mut population: Vec<Individual> = Vec::with_capacity(population_size as usize);
+	let mut point: Vec<f64> = Vec::with_capacity(restrictions.len());
+
+	for restriction in restrictions {
+		point.push(restriction.1 * rand::random::<f64>() + restriction.0);
+	}
+
+	point
+}
+
+pub fn quadratic_population_factory(population_size: usize) -> Vec<Individual> {
+  let mut population: Vec<Individual> = Vec::with_capacity(population_size);
+	let mut restrictions = vec![(-2.0, 2.0), (-2.0, 2.0)];
 
   for _ in 0..population_size {
-    let x = distribution.sample(&mut rng) as f64;
+		let chromosome = point_generator(&restrictions);
 
     population.push(Individual {
-      chromosome: vec![x],
+      chromosome,
       fitness: f64::MAX,
     });
   }
@@ -65,7 +81,7 @@ pub fn quadratic_crossover_operator(father: &Individual, mother: &Individual) ->
 }
 
 pub fn rastrigin_fitness_function(individual: &Individual) -> f64 {
-	let chromosome = individual.chromosome;
+	let chromosome = individual.chromosome.clone();
   return 10_f64 * chromosome.len() as f64 + chromosome.iter().fold(0_f64, |sum, x| {
     sum + x.powi(2) - 10_f64 * (2_f64 * consts::PI * x).cos()
   })

--- a/src/ga/individual.rs
+++ b/src/ga/individual.rs
@@ -33,10 +33,3 @@ impl Ord for Individual {
     unimplemented!();
   }
 }
-//
-// impl Display for Individual {
-//   fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-//     todo!()
-//
-//   }
-// }

--- a/src/ga/individual.rs
+++ b/src/ga/individual.rs
@@ -1,5 +1,4 @@
 use std::cmp::Ordering;
-use std::fmt::{Display, Formatter};
 use serde::Serialize;
 
 #[derive(Clone, Debug, Serialize)]

--- a/src/ga/operators.rs
+++ b/src/ga/operators.rs
@@ -1,0 +1,3 @@
+pub mod selection;
+pub mod crossover;
+pub mod mutation;

--- a/src/ga/operators/crossover.rs
+++ b/src/ga/operators/crossover.rs
@@ -6,17 +6,21 @@ pub fn single_point(parent1: &Individual, parent2: &Individual) -> (Individual, 
 	// FIXME: Handle cases when 0 or parent1.chromosome.len() - 1 are selected (there is only 1 child then)
 	// thus we must handle such case manually to produce second children.
 
-	let cut_point: usize = rand::thread_rng().gen_range(0..parent1.chromosome.len());
+	debug_assert!(parent1.chromosome.len() == parent2.chromosome.len());
 
-	let mut child1_chromosome = Vec::with_capacity(parent1.chromosome.len());
-	let mut child2_chromosome = Vec::with_capacity(parent1.chromosome.len());
+	let chromosome_len = parent1.chromosome.len();
+
+	let cut_point: usize = rand::thread_rng().gen_range(0..chromosome_len);
+
+	let mut child1_chromosome = Vec::with_capacity(chromosome_len);
+	let mut child2_chromosome = Vec::with_capacity(chromosome_len);
 
 	for locus in 0..cut_point {
 		child1_chromosome.push(parent1.chromosome[locus]);
 		child2_chromosome.push(parent2.chromosome[locus]);
 	}
 
-	for locus in cut_point..parent1.chromosome.len() {
+	for locus in cut_point..chromosome_len {
 		child1_chromosome.push(parent2.chromosome[locus]);
 		child2_chromosome.push(parent1.chromosome[locus]);
 	}

--- a/src/ga/operators/crossover.rs
+++ b/src/ga/operators/crossover.rs
@@ -1,0 +1,35 @@
+use rand::Rng;
+
+use crate::ga::Individual;
+
+pub fn single_point(parent1: &Individual, parent2: &Individual) -> (Individual, Individual) {
+	// FIXME: Handle cases when 0 or parent1.chromosome.len() - 1 are selected (there is only 1 child then)
+	// thus we must handle such case manually to produce second children.
+
+	let cut_point: usize = rand::thread_rng().gen_range(0..parent1.chromosome.len());
+
+	let mut child1_chromosome = Vec::with_capacity(parent1.chromosome.len());
+	let mut child2_chromosome = Vec::with_capacity(parent1.chromosome.len());
+
+	for locus in 0..cut_point {
+		child1_chromosome.push(parent1.chromosome[locus]);
+		child2_chromosome.push(parent2.chromosome[locus]);
+	}
+
+	for locus in cut_point..parent1.chromosome.len() {
+		child1_chromosome.push(parent2.chromosome[locus]);
+		child2_chromosome.push(parent1.chromosome[locus]);
+	}
+
+
+	(
+		Individual {
+			chromosome: child1_chromosome,
+			fitness: 0.0,
+		},
+		Individual {
+			chromosome: child2_chromosome,
+			fitness: 0.0,
+		},
+	)
+}

--- a/src/ga/operators/mutation.rs
+++ b/src/ga/operators/mutation.rs
@@ -1,5 +1,3 @@
-use rand::distributions::Uniform;
-
 use crate::ga::Individual;
 
 pub fn range_compliment(individual: &mut Individual) -> Individual {

--- a/src/ga/operators/mutation.rs
+++ b/src/ga/operators/mutation.rs
@@ -1,0 +1,7 @@
+use rand::distributions::Uniform;
+
+use crate::ga::Individual;
+
+pub fn range_compliment(individual: &mut Individual) -> Individual {
+	individual.to_owned()
+}

--- a/src/ga/operators/selection.rs
+++ b/src/ga/operators/selection.rs
@@ -16,9 +16,12 @@ pub fn roulette_wheel(population: &Population, count: usize) -> Vec<&Individual>
 
 			if crt_sum > border {
 				selected.push(individual);
+				break;
 			}
 		}
 	}
+
+	println!("Roulette whell result len: {}", selected.len());
 
 	selected
 }

--- a/src/ga/operators/selection.rs
+++ b/src/ga/operators/selection.rs
@@ -1,0 +1,24 @@
+use crate::ga::{Population, Individual};
+
+pub fn roulette_wheel(population: &Population, count: usize) -> Vec<&Individual> {
+	let total_fitness: f64 = population.into_iter()
+		.map(|individual| individual.fitness)
+		.sum();
+
+	let mut selected: Vec<&Individual> = Vec::with_capacity(count);
+
+	for i in 0..count {
+		let border = total_fitness * rand::random::<f64>();
+
+		let mut crt_sum = 0.0;
+		for individual in population {
+			crt_sum += individual.fitness;
+
+			if crt_sum > border {
+				selected.push(individual);
+			}
+		}
+	}
+
+	selected
+}

--- a/src/ga/operators/selection.rs
+++ b/src/ga/operators/selection.rs
@@ -7,7 +7,7 @@ pub fn roulette_wheel(population: &Population, count: usize) -> Vec<&Individual>
 
 	let mut selected: Vec<&Individual> = Vec::with_capacity(count);
 
-	for i in 0..count {
+	for _ in 0..count {
 		let border = total_fitness * rand::random::<f64>();
 
 		let mut crt_sum = 0.0;

--- a/src/ga/operators/selection.rs
+++ b/src/ga/operators/selection.rs
@@ -21,7 +21,5 @@ pub fn roulette_wheel(population: &Population, count: usize) -> Vec<&Individual>
 		}
 	}
 
-	println!("Roulette whell result len: {}", selected.len());
-
 	selected
 }

--- a/src/ga/probe/json_probe.rs
+++ b/src/ga/probe/json_probe.rs
@@ -1,6 +1,6 @@
-use std::fs::{copy, File};
+use std::fs::File;
 use crate::ga::{Probe, Individual};
-use serde::{Serialize};
+use serde::Serialize;
 use serde_json;
 
 #[derive(Serialize)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -13,7 +13,7 @@ fn main() {
 		.set_crossover_operator(ga::operators::crossover::single_point)
 		.set_mutation_operator(ga::operators::mutation::range_compliment)
 		.set_population_generator(ga::example::quadratic_population_factory)
-		.set_eps(0.1)
+		.set_eps(0.01)
     .build()
     .run();
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,9 +4,6 @@ mod pso;
 mod ff;
 mod examples;
 
-use ga::*;
-
-
 fn main() {
   let res = ga::Builder::new()
     .set_max_generation_count(100)
@@ -22,4 +19,3 @@ fn main() {
 
 	println!("{:?}", res);
 }
-

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,10 +8,18 @@ use ga::*;
 
 
 fn main() {
-  let mut ga_instance = ga::Builder::new()
+  let res = ga::Builder::new()
     .set_max_generation_count(100)
     .set_mutation_rate(0.5f64)
+		.set_population_size(100)
+		.set_fitness_fn(ga::example::quadratic_fn)
+		.set_crossover_operator(ga::operators::crossover::single_point)
+		.set_mutation_operator(ga::operators::mutation::range_compliment)
+		.set_population_generator(ga::example::quadratic_population_factory)
+		.set_eps(0.1)
     .build()
     .run();
+
+	println!("{:?}", res);
 }
 


### PR DESCRIPTION
## Description

This PR cleans up GA implementation and adds basic genetic operators.

* Cleaned up & restructured GA code so from now on it is possible to exchange operator implementations.
* Fixed `ga::Builder`
* Added some basic genetic operators:
  * Single point crossover
  * Roulette wheel selection
  * Stub mutation (waiting for bitstring individual representation)

## Linked issues

This PR pushes #21, however it is not there yet.

## Important implementation details

<!-- if any, optional section -->
