### PR TITLE
feat: add first type of rank selection 

### DIFF
--- a/src/ga/operators/selection.rs
+++ b/src/ga/operators/selection.rs
@@ -1,3 +1,5 @@
+use rand::Rng;
+
 use crate::ga::individual::{ChromosomeWrapper, Chromosome};
 
 pub fn roulette_wheel<T: Chromosome, S: ChromosomeWrapper<T>>(population: &Vec<S>, count: usize) -> Vec<&S> {
@@ -31,6 +33,30 @@ pub fn random<T: Chromosome, S: ChromosomeWrapper<T>>(population: &Vec<S>, count
 
 	for i in indices {
 		selected.push(&population[i]);
+	}
+
+	selected
+}
+
+pub fn rank<T: Chromosome, S: ChromosomeWrapper<T>>(population: &Vec<S>, count: usize) -> Vec<&S> {
+	// TODO: Second implementation with r parameter
+
+	let mut selected: Vec<&S> = Vec::with_capacity(count);
+
+	let population_len = population.len();
+	for _ in 0..count {
+		// TODO: Consider creating two random index permutations and then iterating over them
+		// instead of N times using random.
+		let p1 = & population[rand::thread_rng().gen_range(0..population_len)];
+		let p2 = &population[rand::thread_rng().gen_range(0..population_len)];
+
+		selected.push(
+			if p1.get_fitness() >= p2.get_fitness() {
+				p1
+			} else {
+				p2
+			}
+		)
 	}
 
 	selected

--- a/src/ga/operators/selection.rs
+++ b/src/ga/operators/selection.rs
@@ -1,3 +1,5 @@
+use rand::seq::SliceRandom;
+
 use crate::ga::individual::{ChromosomeWrapper, Chromosome};
 
 pub fn roulette_wheel<T: Chromosome, S: ChromosomeWrapper<T>>(population: &Vec<S>, count: usize) -> Vec<&S> {
@@ -19,6 +21,18 @@ pub fn roulette_wheel<T: Chromosome, S: ChromosomeWrapper<T>>(population: &Vec<S
 				break;
 			}
 		}
+	}
+
+	selected
+}
+
+pub fn random<T: Chromosome, S: ChromosomeWrapper<T>>(population: &Vec<S>, count: usize) -> Vec<&S> {
+	// We must use index API, as we want to return vector of references, not vector of actual items
+	let indices = rand::seq::index::sample(&mut rand::thread_rng(), population.len(), count);
+	let mut selected: Vec<&S> = Vec::with_capacity(count);
+
+	for i in indices {
+		selected.push(&population[i]);
 	}
 
 	selected

--- a/src/ga/operators/selection.rs
+++ b/src/ga/operators/selection.rs
@@ -1,5 +1,3 @@
-use rand::seq::SliceRandom;
-
 use crate::ga::individual::{ChromosomeWrapper, Chromosome};
 
 pub fn roulette_wheel<T: Chromosome, S: ChromosomeWrapper<T>>(population: &Vec<S>, count: usize) -> Vec<&S> {


### PR DESCRIPTION
## Description

Should be merged only after

* #69 

is merged.

Added missing selection operator. 

This is one of two popular implementations. Second one has additional `r` parameter, which is used to decide which of random selected individuals to use as a parent. I left the second implementation behind for now, as presence of additional parameter raises some problems with our current approach to operator implementations. Namely we can't just add additional param to function declaration as it would break existing selection operator API in GA implementation (how do we decide whether to pass 2 or 3 params to operator in runtime?). One possible solution might be to implement operators as traits (concrete implementations as structs with `FnMut` trait implemented). Such approach would not only allow for operator parameterization but also for some kind of function overload which is not present in Rust.

## Linked issues

Closes #37 

## Important implementation details

N/A
