### PR TITLE
feat: add tournament selection operator

### DIFF
--- a/src/ga/operators/selection.rs
+++ b/src/ga/operators/selection.rs
@@ -1,3 +1,5 @@
+use rand::Rng;
+
 use crate::ga::individual::{ChromosomeWrapper, Chromosome};
 
 pub fn roulette_wheel<T: Chromosome, S: ChromosomeWrapper<T>>(population: &Vec<S>, count: usize) -> Vec<&S> {
@@ -31,6 +33,30 @@ pub fn random<T: Chromosome, S: ChromosomeWrapper<T>>(population: &Vec<S>, count
 
 	for i in indices {
 		selected.push(&population[i]);
+	}
+
+	selected
+}
+
+pub fn rank<T: Chromosome, S: ChromosomeWrapper<T>>(population: &Vec<S>, count: usize) -> Vec<&S> {
+	// TODO: Second implementation with r parameter
+
+	let mut selected: Vec<&S> = Vec::with_capacity(count);
+
+	let population_len = population.len();
+	for _ in 0..count {
+		// TODO: Consider creating two random index permutations and then iterating over them
+		// instead of N times using random.
+		let p1 = & population[rand::thread_rng().gen_range(0..population_len)];
+		let p2 = &population[rand::thread_rng().gen_range(0..population_len)];
+
+		selected.push(
+			if p1.get_fitness() >= p2.get_fitness() {
+				p1
+			} else {
+				p2
+			}
+		)
 	}
 
 	selected

--- a/src/ga/operators/selection.rs
+++ b/src/ga/operators/selection.rs
@@ -1,3 +1,5 @@
+use rand::seq::SliceRandom;
+
 use crate::ga::individual::{ChromosomeWrapper, Chromosome};
 
 pub fn roulette_wheel<T: Chromosome, S: ChromosomeWrapper<T>>(population: &Vec<S>, count: usize) -> Vec<&S> {
@@ -19,6 +21,18 @@ pub fn roulette_wheel<T: Chromosome, S: ChromosomeWrapper<T>>(population: &Vec<S
 				break;
 			}
 		}
+	}
+
+	selected
+}
+
+pub fn random<T: Chromosome, S: ChromosomeWrapper<T>>(population: &Vec<S>, count: usize) -> Vec<&S> {
+	// We must use index API, as we want to return vector of references, not vector of actual items
+	let indices = rand::seq::index::sample(&mut rand::thread_rng(), population.len(), count);
+	let mut selected: Vec<&S> = Vec::with_capacity(count);
+
+	for i in indices {
+		selected.push(&population[i]);
 	}
 
 	selected

--- a/src/ga/operators/selection.rs
+++ b/src/ga/operators/selection.rs
@@ -61,3 +61,22 @@ pub fn rank<T: Chromosome, S: ChromosomeWrapper<T>>(population: &Vec<S>, count: 
 
 	selected
 }
+
+pub fn tournament<T: Chromosome, S: ChromosomeWrapper<T>>(population: &Vec<S>, count: usize) -> Vec<&S> {
+	// TODO: This operator must be parametrized...
+	// For now I fix value of this parameter
+	let tournament_size = population.len() / 5;
+
+	assert!(tournament_size > 0);
+
+	let mut selected: Vec<&S> = Vec::with_capacity(count);
+
+	for _ in 0..count {
+		let tournament_indices = rand::seq::index::sample(&mut rand::thread_rng(), population.len(), tournament_size);
+		// FIXME: Check wheter the tournament_indices is empty or handle option below.
+		let best_idv  = tournament_indices.into_iter().map(|i| &population[i]).max().unwrap();
+		selected.push(best_idv);
+	}
+
+	selected
+}

--- a/src/ga/operators/selection.rs
+++ b/src/ga/operators/selection.rs
@@ -1,5 +1,3 @@
-use rand::seq::SliceRandom;
-
 use crate::ga::individual::{ChromosomeWrapper, Chromosome};
 
 pub fn roulette_wheel<T: Chromosome, S: ChromosomeWrapper<T>>(population: &Vec<S>, count: usize) -> Vec<&S> {


### PR DESCRIPTION
## Description

Should be merged only after 

* #71 

is merged.

Added tournament selection operator. 

Due to restrictions coming from construction of our API, it cannot be parameterized. However this is to be changed when idea mentioned in description of #71 is implemented.

## Linked issues

Resolves #38

## Important implementation details

<!-- if any, optional section -->
