### PR TITLE
feat: add stochastic universal sampling selection operator

### DIFF
--- a/src/ga/operators/selection.rs
+++ b/src/ga/operators/selection.rs
@@ -1,3 +1,5 @@
+use rand::Rng;
+
 use crate::ga::individual::{ChromosomeWrapper, Chromosome};
 
 pub fn roulette_wheel<T: Chromosome, S: ChromosomeWrapper<T>>(population: &Vec<S>, count: usize) -> Vec<&S> {
@@ -31,6 +33,30 @@ pub fn random<T: Chromosome, S: ChromosomeWrapper<T>>(population: &Vec<S>, count
 
 	for i in indices {
 		selected.push(&population[i]);
+	}
+
+	selected
+}
+
+pub fn rank<T: Chromosome, S: ChromosomeWrapper<T>>(population: &Vec<S>, count: usize) -> Vec<&S> {
+	// TODO: Second implementation with r parameter
+
+	let mut selected: Vec<&S> = Vec::with_capacity(count);
+
+	let population_len = population.len();
+	for _ in 0..count {
+		// TODO: Consider creating two random index permutations and then iterating over them
+		// instead of N times using random.
+		let p1 = & population[rand::thread_rng().gen_range(0..population_len)];
+		let p2 = &population[rand::thread_rng().gen_range(0..population_len)];
+
+		selected.push(
+			if p1.get_fitness() >= p2.get_fitness() {
+				p1
+			} else {
+				p2
+			}
+		)
 	}
 
 	selected

--- a/src/ga/operators/selection.rs
+++ b/src/ga/operators/selection.rs
@@ -1,3 +1,5 @@
+use rand::seq::SliceRandom;
+
 use crate::ga::individual::{ChromosomeWrapper, Chromosome};
 
 pub fn roulette_wheel<T: Chromosome, S: ChromosomeWrapper<T>>(population: &Vec<S>, count: usize) -> Vec<&S> {
@@ -19,6 +21,18 @@ pub fn roulette_wheel<T: Chromosome, S: ChromosomeWrapper<T>>(population: &Vec<S
 				break;
 			}
 		}
+	}
+
+	selected
+}
+
+pub fn random<T: Chromosome, S: ChromosomeWrapper<T>>(population: &Vec<S>, count: usize) -> Vec<&S> {
+	// We must use index API, as we want to return vector of references, not vector of actual items
+	let indices = rand::seq::index::sample(&mut rand::thread_rng(), population.len(), count);
+	let mut selected: Vec<&S> = Vec::with_capacity(count);
+
+	for i in indices {
+		selected.push(&population[i]);
 	}
 
 	selected

--- a/src/ga/operators/selection.rs
+++ b/src/ga/operators/selection.rs
@@ -61,3 +61,22 @@ pub fn rank<T: Chromosome, S: ChromosomeWrapper<T>>(population: &Vec<S>, count: 
 
 	selected
 }
+
+pub fn tournament<T: Chromosome, S: ChromosomeWrapper<T>>(population: &Vec<S>, count: usize) -> Vec<&S> {
+	// TODO: This operator must be parametrized...
+	// For now I fix value of this parameter
+	let tournament_size = population.len() / 5;
+
+	assert!(tournament_size > 0);
+
+	let mut selected: Vec<&S> = Vec::with_capacity(count);
+
+	for _ in 0..count {
+		let tournament_indices = rand::seq::index::sample(&mut rand::thread_rng(), population.len(), tournament_size);
+		// FIXME: Check wheter the tournament_indices is empty or handle option below.
+		let best_idv  = tournament_indices.into_iter().map(|i| &population[i]).max().unwrap();
+		selected.push(best_idv);
+	}
+
+	selected
+}

--- a/src/ga/operators/selection.rs
+++ b/src/ga/operators/selection.rs
@@ -1,5 +1,3 @@
-use rand::seq::SliceRandom;
-
 use crate::ga::individual::{ChromosomeWrapper, Chromosome};
 
 pub fn roulette_wheel<T: Chromosome, S: ChromosomeWrapper<T>>(population: &Vec<S>, count: usize) -> Vec<&S> {

--- a/src/ga/operators/selection.rs
+++ b/src/ga/operators/selection.rs
@@ -80,3 +80,31 @@ pub fn tournament<T: Chromosome, S: ChromosomeWrapper<T>>(population: &Vec<S>, c
 
 	selected
 }
+
+pub fn stochastic_universal_sampling<T: Chromosome, S: ChromosomeWrapper<T>>(population: &Vec<S>, count: usize) -> Vec<&S> {
+	let total_fitness: f64 = population.into_iter()
+		.map(|indiv| indiv.get_fitness())
+		.sum();
+
+	let mut selected: Vec<&S> = Vec::with_capacity(count);
+
+	let distance_between_pointers = total_fitness / (count as f64);
+
+	assert!(distance_between_pointers > 0.0);
+
+	let mut pointer_pos = rand::thread_rng().gen_range(0.0..=distance_between_pointers);
+
+	let mut curr_sum = 0.0;
+	for idv in population {
+		curr_sum += idv.get_fitness();
+
+		while curr_sum >= pointer_pos {
+			selected.push(idv);
+			pointer_pos += distance_between_pointers;
+		}
+	}
+
+	assert_eq!(selected.len(), count);
+
+	selected
+}


### PR DESCRIPTION
## Description

Should be merged only after

* #72 

is merged.

Added SUS selection operator for GA. 

## Linked issues

Closes #40

## Important implementation details

This implementation allows for multiple addition of single individual to the selected pool in case it spans over multiple pointer positions. 

