### PR TITLE
refact: implement GA operators as traits

### DIFF
--- a/src/examples.rs
+++ b/src/examples.rs
@@ -44,7 +44,7 @@ pub fn ga_example() {
 		.set_population_size(100)
 		.set_fitness_fn(ga::example::quadratic_fn)
 		.set_crossover_operator(Box::new(ga::operators::crossover::SinglePoint {}))
-		.set_mutation_operator(ga::operators::mutation::range_compliment)
+		.set_mutation_operator(Box::new(ga::operators::mutation::Identity {}))
 		.set_population_generator(ga::example::quadratic_population_factory)
 		.set_selection_operator(Box::new(ga::operators::selection::RouletteWheel {}))
 		.set_eps(0.01)

--- a/src/examples.rs
+++ b/src/examples.rs
@@ -43,7 +43,7 @@ pub fn ga_example() {
     .set_mutation_rate(0.5f64)
 		.set_population_size(100)
 		.set_fitness_fn(ga::example::quadratic_fn)
-		.set_crossover_operator(ga::operators::crossover::single_point)
+		.set_crossover_operator(Box::new(ga::operators::crossover::SinglePoint {}))
 		.set_mutation_operator(ga::operators::mutation::range_compliment)
 		.set_population_generator(ga::example::quadratic_population_factory)
 		.set_selection_operator(Box::new(ga::operators::selection::RouletteWheel {}))

--- a/src/examples.rs
+++ b/src/examples.rs
@@ -46,6 +46,7 @@ pub fn ga_example() {
 		.set_crossover_operator(ga::operators::crossover::single_point)
 		.set_mutation_operator(ga::operators::mutation::range_compliment)
 		.set_population_generator(ga::example::quadratic_population_factory)
+		.set_selection_operator(Box::new(ga::operators::selection::RouletteWheel {}))
 		.set_eps(0.01)
 		.set_probe(Box::new(ga::probe::stdout_probe::StdoutProbe{}))
     .build()

--- a/src/ga.rs
+++ b/src/ga.rs
@@ -12,12 +12,18 @@ pub use probe::csv_probe::CsvProbe;
 pub use example::*;
 pub use builder::*;
 
-use self::{individual::{Chromosome, ChromosomeWrapper}, operators::{selection::SelectionOperator, crossover::CrossoverOperator}};
+use self::{
+	individual::{Chromosome, ChromosomeWrapper},
+	operators::{
+		selection::SelectionOperator,
+		crossover::CrossoverOperator,
+		mutation::MutationOperator
+	}
+};
 
 // trait FitnessFn
 
 type FitnessFn<S> = fn(&S) -> f64;
-type MutationOperator<S> = fn(&mut S) -> ();
 type PopulationGenerator<S> = fn(usize) -> Vec<S>;
 
 pub struct GAParams {
@@ -62,7 +68,7 @@ pub struct GAConfig<T: Chromosome, S: ChromosomeWrapper<T>> {
 	pub params: GAParams,
 	// pub ops: GAOps<S>,
   pub fitness_fn: FitnessFn<S>,
-  pub mutation_operator: MutationOperator<S>,
+  pub mutation_operator: Box<dyn MutationOperator<T, S>>,
   pub crossover_operator: Box<dyn CrossoverOperator<T, S>>,
 	pub selection_operator: Box<dyn SelectionOperator<T, S>>,
   pub population_factory: PopulationGenerator<S>,

--- a/src/ga.rs
+++ b/src/ga.rs
@@ -12,7 +12,7 @@ pub use probe::csv_probe::CsvProbe;
 pub use example::*;
 pub use builder::*;
 
-use self::individual::{Chromosome, ChromosomeWrapper};
+use self::{individual::{Chromosome, ChromosomeWrapper}, operators::selection::SelectionOperator};
 
 // trait FitnessFn
 
@@ -65,6 +65,7 @@ pub struct GAConfig<T: Chromosome, S: ChromosomeWrapper<T>> {
   pub fitness_fn: FitnessFn<S>,
   pub mutation_operator: MutationOperator<S>,
   pub crossover_operator: CrossoverOperator<S>,
+	pub selection_operator: Box<dyn SelectionOperator<T, S>>,
   pub population_factory: PopulationGenerator<S>,
   pub probe: Box<dyn Probe<T, S>>
 }
@@ -121,7 +122,7 @@ impl<T: Chromosome, S: ChromosomeWrapper<T>> GeneticAlgorithm<T, S> {
 			// 4. Create mating pool by applying selection operator.
 			// FIXME: This should be taken from config, but as for now, I'm taking it directly
 			// from operators module.
-			let mating_pool: Vec<&S> = operators::selection::roulette_wheel(&population, population.len());
+			let mating_pool: Vec<&S> = self.config.selection_operator.apply(&population, population.len());
 
 			// 5. From mating pool create new generation (apply crossover & mutation).
 			let mut children: Vec<S> = Vec::with_capacity(self.config.params.population_size);

--- a/src/ga/builder.rs
+++ b/src/ga/builder.rs
@@ -1,3 +1,4 @@
+use super::operators::selection::SelectionOperator;
 use super::{GeneticAlgorithm, GAConfig, FitnessFn, MutationOperator, CrossoverOperator, PopulationGenerator, Probe, GAParams};
 use super::individual::{ChromosomeWrapper, Chromosome};
 
@@ -6,6 +7,7 @@ struct GAConfigOpt<T: Chromosome, S: ChromosomeWrapper<T>> {
   fitness_fn: Option<FitnessFn<S>>,
   mutation_operator: Option<MutationOperator<S>>,
   crossover_operator: Option<CrossoverOperator<S>>,
+	selection_operator: Option<Box<dyn SelectionOperator<T, S>>>,
   population_factory: Option<PopulationGenerator<S>>,
   probe: Option<Box<dyn Probe<T, S>>>,
 }
@@ -17,6 +19,7 @@ impl<T: Chromosome, S: ChromosomeWrapper<T>> Default for GAConfigOpt<T, S> {
 			fitness_fn: None,
 			mutation_operator: None,
 			crossover_operator: None,
+			selection_operator: None,
 			population_factory: None,
 			probe: None
 		}
@@ -31,6 +34,7 @@ impl<T: Chromosome, S: ChromosomeWrapper<T>> Into<GAConfig<T, S>> for GAConfigOp
 			fitness_fn: self.fitness_fn.unwrap(),
 			mutation_operator: self.mutation_operator.unwrap(),
 			crossover_operator: self.crossover_operator.unwrap(),
+			selection_operator: self.selection_operator.unwrap(),
 			population_factory: self.population_factory.unwrap(),
 			probe: self.probe.unwrap()
 		}
@@ -97,6 +101,11 @@ impl<T: Chromosome, S: ChromosomeWrapper<T>> Builder<T, S> {
     self.config.crossover_operator = Some(crossover_op);
     self
   }
+
+	pub fn set_selection_operator(mut self, selection_op: Box<dyn SelectionOperator<T, S>>) -> Self {
+		self.config.selection_operator = Some(selection_op);
+		self
+	}
 
   pub fn set_population_generator(mut self, generator: PopulationGenerator<S>) -> Self {
     self.config.population_factory = Some(generator);

--- a/src/ga/builder.rs
+++ b/src/ga/builder.rs
@@ -6,7 +6,7 @@ struct GAConfigOpt<T: Chromosome, S: ChromosomeWrapper<T>> {
 	params: Option<GAParams>,
   fitness_fn: Option<FitnessFn<S>>,
   mutation_operator: Option<MutationOperator<S>>,
-  crossover_operator: Option<CrossoverOperator<S>>,
+  crossover_operator: Option<Box<dyn CrossoverOperator<T, S>>>,
 	selection_operator: Option<Box<dyn SelectionOperator<T, S>>>,
   population_factory: Option<PopulationGenerator<S>>,
   probe: Option<Box<dyn Probe<T, S>>>,
@@ -97,7 +97,7 @@ impl<T: Chromosome, S: ChromosomeWrapper<T>> Builder<T, S> {
     self
   }
 
-  pub fn set_crossover_operator(mut self, crossover_op: CrossoverOperator<S>) -> Self {
+  pub fn set_crossover_operator(mut self, crossover_op: Box<dyn CrossoverOperator<T, S>>) -> Self {
     self.config.crossover_operator = Some(crossover_op);
     self
   }

--- a/src/ga/builder.rs
+++ b/src/ga/builder.rs
@@ -5,7 +5,7 @@ use super::individual::{ChromosomeWrapper, Chromosome};
 struct GAConfigOpt<T: Chromosome, S: ChromosomeWrapper<T>> {
 	params: Option<GAParams>,
   fitness_fn: Option<FitnessFn<S>>,
-  mutation_operator: Option<MutationOperator<S>>,
+  mutation_operator: Option<Box<dyn MutationOperator<T, S>>>,
   crossover_operator: Option<Box<dyn CrossoverOperator<T, S>>>,
 	selection_operator: Option<Box<dyn SelectionOperator<T, S>>>,
   population_factory: Option<PopulationGenerator<S>>,
@@ -92,7 +92,7 @@ impl<T: Chromosome, S: ChromosomeWrapper<T>> Builder<T, S> {
     self
   }
 
-  pub fn set_mutation_operator(mut self, mutation_op: MutationOperator<S>) -> Self {
+  pub fn set_mutation_operator(mut self, mutation_op: Box<dyn MutationOperator<T, S>>) -> Self {
     self.config.mutation_operator = Some(mutation_op);
     self
   }

--- a/src/ga/operators/crossover.rs
+++ b/src/ga/operators/crossover.rs
@@ -15,8 +15,6 @@ where
 	let chromosome_len = parent1.get_chromosome().len();
 	let cut_point = rand::thread_rng().gen_range(0..chromosome_len);
 
-	println!("Cut point: {}", cut_point);
-
 	let mut child1 = ChWrapperT::new();
 	let mut child2 = ChWrapperT::new();
 

--- a/src/ga/operators/crossover.rs
+++ b/src/ga/operators/crossover.rs
@@ -4,29 +4,35 @@ use push_trait::{Push, Nothing};
 use rand::Rng;
 use crate::ga::individual::{ChromosomeWrapper, Chromosome};
 
-pub fn single_point<GeneT, ChT, ChWrapperT>(
-	parent1: &ChWrapperT,
-	parent2: &ChWrapperT) -> (ChWrapperT, ChWrapperT)
+pub trait CrossoverOperator<T: Chromosome, S: ChromosomeWrapper<T>> {
+	fn apply(&mut self, parent1: &S, parent2: &S) -> (S, S);
+}
+
+pub struct SinglePoint;
+
+impl<GeneT, ChT, ChWrapperT> CrossoverOperator<ChT, ChWrapperT> for SinglePoint
 where
 	ChT: Chromosome + Index<usize, Output = GeneT> + Push<GeneT, PushedOut = Nothing>,
 	ChWrapperT: ChromosomeWrapper<ChT>,
 	GeneT: Copy
 {
-	let chromosome_len = parent1.get_chromosome().len();
-	let cut_point = rand::thread_rng().gen_range(0..chromosome_len);
+	fn apply(&mut self, parent1: &ChWrapperT, parent2: &ChWrapperT) -> (ChWrapperT, ChWrapperT) {
+		let chromosome_len = parent1.get_chromosome().len();
+		let cut_point = rand::thread_rng().gen_range(0..chromosome_len);
 
-	let mut child1 = ChWrapperT::new();
-	let mut child2 = ChWrapperT::new();
+		let mut child1 = ChWrapperT::new();
+		let mut child2 = ChWrapperT::new();
 
-	for locus in 0..cut_point {
-		child1.get_chromosome_mut().push(parent1.get_chromosome()[locus]);
-		child2.get_chromosome_mut().push(parent2.get_chromosome()[locus]);
+		for locus in 0..cut_point {
+			child1.get_chromosome_mut().push(parent1.get_chromosome()[locus]);
+			child2.get_chromosome_mut().push(parent2.get_chromosome()[locus]);
+		}
+
+		for locus in cut_point..chromosome_len {
+			child1.get_chromosome_mut().push(parent2.get_chromosome()[locus]);
+			child2.get_chromosome_mut().push(parent1.get_chromosome()[locus]);
+		}
+
+		(child1, child2)
 	}
-
-	for locus in cut_point..chromosome_len {
-		child1.get_chromosome_mut().push(parent2.get_chromosome()[locus]);
-		child2.get_chromosome_mut().push(parent1.get_chromosome()[locus]);
-	}
-
-	(child1, child2)
 }

--- a/src/ga/operators/mutation.rs
+++ b/src/ga/operators/mutation.rs
@@ -1,5 +1,11 @@
 use crate::ga::individual::{ChromosomeWrapper, Chromosome};
 
-pub fn range_compliment<T: Chromosome, S: ChromosomeWrapper<T>>(individual: &mut S) -> () {
-	// individual.to_owned()
+pub trait MutationOperator<T: Chromosome, S: ChromosomeWrapper<T>> {
+	fn apply(&mut self, indivudial: &mut S) -> ();
+}
+
+pub struct Identity;
+
+impl<T: Chromosome, S: ChromosomeWrapper<T>> MutationOperator<T, S> for Identity {
+	fn apply(&mut self, indivudial: &mut S) -> () {}
 }

--- a/src/ga/operators/selection.rs
+++ b/src/ga/operators/selection.rs
@@ -3,7 +3,7 @@ use rand::Rng;
 use crate::ga::individual::{ChromosomeWrapper, Chromosome};
 
 pub trait SelectionOperator<T: Chromosome, S: ChromosomeWrapper<T>> {
-	fn apply<'a> (&mut self, population: &'a Vec<S>, count: usize) -> Vec<&'a S>;
+	fn apply<'a>(&mut self, population: &'a Vec<S>, count: usize) -> Vec<&'a S>;
 }
 
 pub struct RouletteWheel;
@@ -36,7 +36,7 @@ impl<T: Chromosome, S: ChromosomeWrapper<T>> SelectionOperator<T, S> for Roulett
 pub struct Random;
 
 impl<T: Chromosome, S: ChromosomeWrapper<T>> SelectionOperator<T, S> for Random {
-	fn apply<'a> (&mut self, population: &'a Vec<S>, count: usize) -> Vec<&'a S> {
+	fn apply<'a>(&mut self, population: &'a Vec<S>, count: usize) -> Vec<&'a S> {
 		// We must use index API, as we want to return vector of references, not vector of actual items
 		let indices = rand::seq::index::sample(&mut rand::thread_rng(), population.len(), count);
 		let mut selected: Vec<&S> = Vec::with_capacity(count);
@@ -51,7 +51,7 @@ impl<T: Chromosome, S: ChromosomeWrapper<T>> SelectionOperator<T, S> for Random 
 pub struct Rank;
 
 impl<T: Chromosome, S: ChromosomeWrapper<T>> SelectionOperator<T, S> for Rank {
-	fn apply<'a> (&mut self, population: &'a Vec<S>, count: usize) -> Vec<&'a S> {
+	fn apply<'a>(&mut self, population: &'a Vec<S>, count: usize) -> Vec<&'a S> {
 		// TODO: Second implementation with r parameter
 
 		let mut selected: Vec<&S> = Vec::with_capacity(count);
@@ -79,7 +79,7 @@ impl<T: Chromosome, S: ChromosomeWrapper<T>> SelectionOperator<T, S> for Rank {
 pub struct Tournament;
 
 impl<T: Chromosome, S: ChromosomeWrapper<T>> SelectionOperator<T, S> for Tournament {
-	fn apply<'a> (&mut self, population: &'a Vec<S>, count: usize) -> Vec<&'a S> {
+	fn apply<'a>(&mut self, population: &'a Vec<S>, count: usize) -> Vec<&'a S> {
 		// TODO: This operator must be parametrized...
 		// For now I fix value of this parameter
 		let tournament_size = population.len() / 5;
@@ -102,7 +102,7 @@ impl<T: Chromosome, S: ChromosomeWrapper<T>> SelectionOperator<T, S> for Tournam
 pub struct StochasticUniversalSampling;
 
 impl<T: Chromosome, S: ChromosomeWrapper<T>> SelectionOperator<T, S> for StochasticUniversalSampling {
-	fn apply<'a> (&mut self, population: &'a Vec<S>, count: usize) -> Vec<&'a S> {
+	fn apply<'a>(&mut self, population: &'a Vec<S>, count: usize) -> Vec<&'a S> {
 		let total_fitness: f64 = population.into_iter()
 			.map(|indiv| indiv.get_fitness())
 			.sum();

--- a/src/ga/operators/selection.rs
+++ b/src/ga/operators/selection.rs
@@ -1,3 +1,5 @@
+use rand::Rng;
+
 use crate::ga::individual::{ChromosomeWrapper, Chromosome};
 
 pub fn roulette_wheel<T: Chromosome, S: ChromosomeWrapper<T>>(population: &Vec<S>, count: usize) -> Vec<&S> {
@@ -31,6 +33,30 @@ pub fn random<T: Chromosome, S: ChromosomeWrapper<T>>(population: &Vec<S>, count
 
 	for i in indices {
 		selected.push(&population[i]);
+	}
+
+	selected
+}
+
+pub fn rank<T: Chromosome, S: ChromosomeWrapper<T>>(population: &Vec<S>, count: usize) -> Vec<&S> {
+	// TODO: Second implementation with r parameter
+
+	let mut selected: Vec<&S> = Vec::with_capacity(count);
+
+	let population_len = population.len();
+	for _ in 0..count {
+		// TODO: Consider creating two random index permutations and then iterating over them
+		// instead of N times using random.
+		let p1 = & population[rand::thread_rng().gen_range(0..population_len)];
+		let p2 = &population[rand::thread_rng().gen_range(0..population_len)];
+
+		selected.push(
+			if p1.get_fitness() >= p2.get_fitness() {
+				p1
+			} else {
+				p2
+			}
+		)
 	}
 
 	selected

--- a/src/ga/operators/selection.rs
+++ b/src/ga/operators/selection.rs
@@ -1,3 +1,5 @@
+use rand::seq::SliceRandom;
+
 use crate::ga::individual::{ChromosomeWrapper, Chromosome};
 
 pub fn roulette_wheel<T: Chromosome, S: ChromosomeWrapper<T>>(population: &Vec<S>, count: usize) -> Vec<&S> {
@@ -19,6 +21,18 @@ pub fn roulette_wheel<T: Chromosome, S: ChromosomeWrapper<T>>(population: &Vec<S
 				break;
 			}
 		}
+	}
+
+	selected
+}
+
+pub fn random<T: Chromosome, S: ChromosomeWrapper<T>>(population: &Vec<S>, count: usize) -> Vec<&S> {
+	// We must use index API, as we want to return vector of references, not vector of actual items
+	let indices = rand::seq::index::sample(&mut rand::thread_rng(), population.len(), count);
+	let mut selected: Vec<&S> = Vec::with_capacity(count);
+
+	for i in indices {
+		selected.push(&population[i]);
 	}
 
 	selected

--- a/src/ga/operators/selection.rs
+++ b/src/ga/operators/selection.rs
@@ -61,3 +61,22 @@ pub fn rank<T: Chromosome, S: ChromosomeWrapper<T>>(population: &Vec<S>, count: 
 
 	selected
 }
+
+pub fn tournament<T: Chromosome, S: ChromosomeWrapper<T>>(population: &Vec<S>, count: usize) -> Vec<&S> {
+	// TODO: This operator must be parametrized...
+	// For now I fix value of this parameter
+	let tournament_size = population.len() / 5;
+
+	assert!(tournament_size > 0);
+
+	let mut selected: Vec<&S> = Vec::with_capacity(count);
+
+	for _ in 0..count {
+		let tournament_indices = rand::seq::index::sample(&mut rand::thread_rng(), population.len(), tournament_size);
+		// FIXME: Check wheter the tournament_indices is empty or handle option below.
+		let best_idv  = tournament_indices.into_iter().map(|i| &population[i]).max().unwrap();
+		selected.push(best_idv);
+	}
+
+	selected
+}

--- a/src/ga/operators/selection.rs
+++ b/src/ga/operators/selection.rs
@@ -1,5 +1,3 @@
-use rand::seq::SliceRandom;
-
 use crate::ga::individual::{ChromosomeWrapper, Chromosome};
 
 pub fn roulette_wheel<T: Chromosome, S: ChromosomeWrapper<T>>(population: &Vec<S>, count: usize) -> Vec<&S> {

--- a/src/ga/operators/selection.rs
+++ b/src/ga/operators/selection.rs
@@ -80,3 +80,31 @@ pub fn tournament<T: Chromosome, S: ChromosomeWrapper<T>>(population: &Vec<S>, c
 
 	selected
 }
+
+pub fn stochastic_universal_sampling<T: Chromosome, S: ChromosomeWrapper<T>>(population: &Vec<S>, count: usize) -> Vec<&S> {
+	let total_fitness: f64 = population.into_iter()
+		.map(|indiv| indiv.get_fitness())
+		.sum();
+
+	let mut selected: Vec<&S> = Vec::with_capacity(count);
+
+	let distance_between_pointers = total_fitness / (count as f64);
+
+	assert!(distance_between_pointers > 0.0);
+
+	let mut pointer_pos = rand::thread_rng().gen_range(0.0..=distance_between_pointers);
+
+	let mut curr_sum = 0.0;
+	for idv in population {
+		curr_sum += idv.get_fitness();
+
+		while curr_sum >= pointer_pos {
+			selected.push(idv);
+			pointer_pos += distance_between_pointers;
+		}
+	}
+
+	assert_eq!(selected.len(), count);
+
+	selected
+}

--- a/src/ga/operators/selection.rs
+++ b/src/ga/operators/selection.rs
@@ -3,13 +3,13 @@ use rand::Rng;
 use crate::ga::individual::{ChromosomeWrapper, Chromosome};
 
 pub trait SelectionOperator<T: Chromosome, S: ChromosomeWrapper<T>> {
-	fn apply<'a> (&self, population: &'a Vec<S>, count: usize) -> Vec<&'a S>;
+	fn apply<'a> (&mut self, population: &'a Vec<S>, count: usize) -> Vec<&'a S>;
 }
 
 pub struct RouletteWheel;
 
 impl<T: Chromosome, S: ChromosomeWrapper<T>> SelectionOperator<T, S> for RouletteWheel {
-	fn apply<'a> (&self, population: &'a Vec<S>, count: usize) -> Vec<&'a S> {
+	fn apply<'a> (&mut self, population: &'a Vec<S>, count: usize) -> Vec<&'a S> {
 		let total_fitness: f64 = population.into_iter()
 			.map(|indiv| indiv.get_fitness())
 			.sum();
@@ -36,7 +36,7 @@ impl<T: Chromosome, S: ChromosomeWrapper<T>> SelectionOperator<T, S> for Roulett
 pub struct Random;
 
 impl<T: Chromosome, S: ChromosomeWrapper<T>> SelectionOperator<T, S> for Random {
-	fn apply<'a> (&self, population: &'a Vec<S>, count: usize) -> Vec<&'a S> {
+	fn apply<'a> (&mut self, population: &'a Vec<S>, count: usize) -> Vec<&'a S> {
 		// We must use index API, as we want to return vector of references, not vector of actual items
 		let indices = rand::seq::index::sample(&mut rand::thread_rng(), population.len(), count);
 		let mut selected: Vec<&S> = Vec::with_capacity(count);
@@ -51,7 +51,7 @@ impl<T: Chromosome, S: ChromosomeWrapper<T>> SelectionOperator<T, S> for Random 
 pub struct Rank;
 
 impl<T: Chromosome, S: ChromosomeWrapper<T>> SelectionOperator<T, S> for Rank {
-	fn apply<'a> (&self, population: &'a Vec<S>, count: usize) -> Vec<&'a S> {
+	fn apply<'a> (&mut self, population: &'a Vec<S>, count: usize) -> Vec<&'a S> {
 		// TODO: Second implementation with r parameter
 
 		let mut selected: Vec<&S> = Vec::with_capacity(count);
@@ -76,10 +76,10 @@ impl<T: Chromosome, S: ChromosomeWrapper<T>> SelectionOperator<T, S> for Rank {
 	}
 }
 
-pub struct TournamentSelection;
+pub struct Tournament;
 
-impl<T: Chromosome, S: ChromosomeWrapper<T>> SelectionOperator<T, S> for TournamentSelection {
-	fn apply<'a> (&self, population: &'a Vec<S>, count: usize) -> Vec<&'a S> {
+impl<T: Chromosome, S: ChromosomeWrapper<T>> SelectionOperator<T, S> for Tournament {
+	fn apply<'a> (&mut self, population: &'a Vec<S>, count: usize) -> Vec<&'a S> {
 		// TODO: This operator must be parametrized...
 		// For now I fix value of this parameter
 		let tournament_size = population.len() / 5;
@@ -102,7 +102,7 @@ impl<T: Chromosome, S: ChromosomeWrapper<T>> SelectionOperator<T, S> for Tournam
 pub struct StochasticUniversalSampling;
 
 impl<T: Chromosome, S: ChromosomeWrapper<T>> SelectionOperator<T, S> for StochasticUniversalSampling {
-	fn apply<'a> (&self, population: &'a Vec<S>, count: usize) -> Vec<&'a S> {
+	fn apply<'a> (&mut self, population: &'a Vec<S>, count: usize) -> Vec<&'a S> {
 		let total_fitness: f64 = population.into_iter()
 			.map(|indiv| indiv.get_fitness())
 			.sum();

--- a/src/ga/operators/selection.rs
+++ b/src/ga/operators/selection.rs
@@ -2,109 +2,131 @@ use rand::Rng;
 
 use crate::ga::individual::{ChromosomeWrapper, Chromosome};
 
-pub fn roulette_wheel<T: Chromosome, S: ChromosomeWrapper<T>>(population: &Vec<S>, count: usize) -> Vec<&S> {
-	let total_fitness: f64 = population.into_iter()
-		.map(|indiv| indiv.get_fitness())
-		.sum();
+pub trait SelectionOperator<T: Chromosome, S: ChromosomeWrapper<T>> {
+	fn apply(&self, population: &Vec<S>, count: usize) -> Vec<&S>;
+}
 
-	let mut selected: Vec<&S> = Vec::with_capacity(count);
+struct RouletteWheel;
 
-	for _ in 0..count {
-		let threshold = total_fitness * rand::random::<f64>();
+impl<T: Chromosome, S: ChromosomeWrapper<T>> SelectionOperator<T, S> for RouletteWheel {
+	fn apply(&self, population: &Vec<S>, count: usize) -> Vec<&S> {
+		let total_fitness: f64 = population.into_iter()
+			.map(|indiv| indiv.get_fitness())
+			.sum();
 
-		let mut crt_sum = 0.0;
-		for indiv in population {
-			crt_sum += indiv.get_fitness();
+		let mut selected: Vec<&S> = Vec::with_capacity(count);
 
-			if crt_sum > threshold {
-				selected.push(indiv);
-				break;
+		for _ in 0..count {
+			let threshold = total_fitness * rand::random::<f64>();
+
+			let mut crt_sum = 0.0;
+			for indiv in population {
+				crt_sum += indiv.get_fitness();
+
+				if crt_sum > threshold {
+					selected.push(indiv);
+					break;
+				}
 			}
 		}
+		selected
 	}
-
-	selected
 }
 
-pub fn random<T: Chromosome, S: ChromosomeWrapper<T>>(population: &Vec<S>, count: usize) -> Vec<&S> {
-	// We must use index API, as we want to return vector of references, not vector of actual items
-	let indices = rand::seq::index::sample(&mut rand::thread_rng(), population.len(), count);
-	let mut selected: Vec<&S> = Vec::with_capacity(count);
+struct Random;
 
-	for i in indices {
-		selected.push(&population[i]);
-	}
+impl<T: Chromosome, S: ChromosomeWrapper<T>> SelectionOperator<T, S> for Random {
+	fn apply(&self, population: &Vec<S>, count: usize) -> Vec<&S> {
+		// We must use index API, as we want to return vector of references, not vector of actual items
+		let indices = rand::seq::index::sample(&mut rand::thread_rng(), population.len(), count);
+		let mut selected: Vec<&S> = Vec::with_capacity(count);
 
-	selected
-}
-
-pub fn rank<T: Chromosome, S: ChromosomeWrapper<T>>(population: &Vec<S>, count: usize) -> Vec<&S> {
-	// TODO: Second implementation with r parameter
-
-	let mut selected: Vec<&S> = Vec::with_capacity(count);
-
-	let population_len = population.len();
-	for _ in 0..count {
-		// TODO: Consider creating two random index permutations and then iterating over them
-		// instead of N times using random.
-		let p1 = & population[rand::thread_rng().gen_range(0..population_len)];
-		let p2 = &population[rand::thread_rng().gen_range(0..population_len)];
-
-		selected.push(
-			if p1.get_fitness() >= p2.get_fitness() {
-				p1
-			} else {
-				p2
-			}
-		)
-	}
-
-	selected
-}
-
-pub fn tournament<T: Chromosome, S: ChromosomeWrapper<T>>(population: &Vec<S>, count: usize) -> Vec<&S> {
-	// TODO: This operator must be parametrized...
-	// For now I fix value of this parameter
-	let tournament_size = population.len() / 5;
-
-	assert!(tournament_size > 0);
-
-	let mut selected: Vec<&S> = Vec::with_capacity(count);
-
-	for _ in 0..count {
-		let tournament_indices = rand::seq::index::sample(&mut rand::thread_rng(), population.len(), tournament_size);
-		// FIXME: Check wheter the tournament_indices is empty or handle option below.
-		let best_idv  = tournament_indices.into_iter().map(|i| &population[i]).max().unwrap();
-		selected.push(best_idv);
-	}
-
-	selected
-}
-
-pub fn stochastic_universal_sampling<T: Chromosome, S: ChromosomeWrapper<T>>(population: &Vec<S>, count: usize) -> Vec<&S> {
-	let total_fitness: f64 = population.into_iter()
-		.map(|indiv| indiv.get_fitness())
-		.sum();
-
-	let mut selected: Vec<&S> = Vec::with_capacity(count);
-
-	let distance_between_pointers = total_fitness / (count as f64);
-
-	assert!(distance_between_pointers > 0.0);
-
-	let mut pointer_pos = rand::thread_rng().gen_range(0.0..=distance_between_pointers);
-
-	let mut curr_sum = 0.0;
-	for idv in population {
-		curr_sum += idv.get_fitness();
-
-		while curr_sum >= pointer_pos {
-			selected.push(idv);
-			pointer_pos += distance_between_pointers;
+		for i in indices {
+			selected.push(&population[i]);
 		}
+		selected
 	}
+}
 
-	assert_eq!(selected.len(), count);
+struct Rank;
 
-	selected
+impl<T: Chromosome, S: ChromosomeWrapper<T>> SelectionOperator<T, S> for Rank {
+	fn apply(&self, population: &Vec<S>, count: usize) -> Vec<&S> {
+		// TODO: Second implementation with r parameter
+
+		let mut selected: Vec<&S> = Vec::with_capacity(count);
+
+		let population_len = population.len();
+		for _ in 0..count {
+			// TODO: Consider creating two random index permutations and then iterating over them
+			// instead of N times using random.
+			let p1 = & population[rand::thread_rng().gen_range(0..population_len)];
+			let p2 = &population[rand::thread_rng().gen_range(0..population_len)];
+
+			selected.push(
+				if p1.get_fitness() >= p2.get_fitness() {
+					p1
+				} else {
+					p2
+				}
+			)
+		}
+
+		selected
+	}
+}
+
+struct TournamentSelection;
+
+impl<T: Chromosome, S: ChromosomeWrapper<T>> SelectionOperator<T, S> for TournamentSelection {
+	fn apply(&self, population: &Vec<S>, count: usize) -> Vec<&S> {
+		// TODO: This operator must be parametrized...
+		// For now I fix value of this parameter
+		let tournament_size = population.len() / 5;
+
+		assert!(tournament_size > 0);
+
+		let mut selected: Vec<&S> = Vec::with_capacity(count);
+
+		for _ in 0..count {
+			let tournament_indices = rand::seq::index::sample(&mut rand::thread_rng(), population.len(), tournament_size);
+			// FIXME: Check wheter the tournament_indices is empty or handle option below.
+			let best_idv  = tournament_indices.into_iter().map(|i| &population[i]).max().unwrap();
+			selected.push(best_idv);
+		}
+
+		selected
+	}
+}
+
+struct StochasticUniversalSampling;
+
+impl<T: Chromosome, S: ChromosomeWrapper<T>> SelectionOperator<T, S> for StochasticUniversalSampling {
+	fn apply(&self, population: &Vec<S>, count: usize) -> Vec<&S> {
+		let total_fitness: f64 = population.into_iter()
+			.map(|indiv| indiv.get_fitness())
+			.sum();
+
+		let mut selected: Vec<&S> = Vec::with_capacity(count);
+
+		let distance_between_pointers = total_fitness / (count as f64);
+
+		assert!(distance_between_pointers > 0.0);
+
+		let mut pointer_pos = rand::thread_rng().gen_range(0.0..=distance_between_pointers);
+
+		let mut curr_sum = 0.0;
+		for idv in population {
+			curr_sum += idv.get_fitness();
+
+			while curr_sum >= pointer_pos {
+				selected.push(idv);
+				pointer_pos += distance_between_pointers;
+			}
+		}
+
+		assert_eq!(selected.len(), count);
+
+		selected
+	}
 }

--- a/src/ga/operators/selection.rs
+++ b/src/ga/operators/selection.rs
@@ -3,13 +3,13 @@ use rand::Rng;
 use crate::ga::individual::{ChromosomeWrapper, Chromosome};
 
 pub trait SelectionOperator<T: Chromosome, S: ChromosomeWrapper<T>> {
-	fn apply(&self, population: &Vec<S>, count: usize) -> Vec<&S>;
+	fn apply<'a> (&self, population: &'a Vec<S>, count: usize) -> Vec<&'a S>;
 }
 
-struct RouletteWheel;
+pub struct RouletteWheel;
 
 impl<T: Chromosome, S: ChromosomeWrapper<T>> SelectionOperator<T, S> for RouletteWheel {
-	fn apply(&self, population: &Vec<S>, count: usize) -> Vec<&S> {
+	fn apply<'a> (&self, population: &'a Vec<S>, count: usize) -> Vec<&'a S> {
 		let total_fitness: f64 = population.into_iter()
 			.map(|indiv| indiv.get_fitness())
 			.sum();
@@ -33,10 +33,10 @@ impl<T: Chromosome, S: ChromosomeWrapper<T>> SelectionOperator<T, S> for Roulett
 	}
 }
 
-struct Random;
+pub struct Random;
 
 impl<T: Chromosome, S: ChromosomeWrapper<T>> SelectionOperator<T, S> for Random {
-	fn apply(&self, population: &Vec<S>, count: usize) -> Vec<&S> {
+	fn apply<'a> (&self, population: &'a Vec<S>, count: usize) -> Vec<&'a S> {
 		// We must use index API, as we want to return vector of references, not vector of actual items
 		let indices = rand::seq::index::sample(&mut rand::thread_rng(), population.len(), count);
 		let mut selected: Vec<&S> = Vec::with_capacity(count);
@@ -48,10 +48,10 @@ impl<T: Chromosome, S: ChromosomeWrapper<T>> SelectionOperator<T, S> for Random 
 	}
 }
 
-struct Rank;
+pub struct Rank;
 
 impl<T: Chromosome, S: ChromosomeWrapper<T>> SelectionOperator<T, S> for Rank {
-	fn apply(&self, population: &Vec<S>, count: usize) -> Vec<&S> {
+	fn apply<'a> (&self, population: &'a Vec<S>, count: usize) -> Vec<&'a S> {
 		// TODO: Second implementation with r parameter
 
 		let mut selected: Vec<&S> = Vec::with_capacity(count);
@@ -76,10 +76,10 @@ impl<T: Chromosome, S: ChromosomeWrapper<T>> SelectionOperator<T, S> for Rank {
 	}
 }
 
-struct TournamentSelection;
+pub struct TournamentSelection;
 
 impl<T: Chromosome, S: ChromosomeWrapper<T>> SelectionOperator<T, S> for TournamentSelection {
-	fn apply(&self, population: &Vec<S>, count: usize) -> Vec<&S> {
+	fn apply<'a> (&self, population: &'a Vec<S>, count: usize) -> Vec<&'a S> {
 		// TODO: This operator must be parametrized...
 		// For now I fix value of this parameter
 		let tournament_size = population.len() / 5;
@@ -99,10 +99,10 @@ impl<T: Chromosome, S: ChromosomeWrapper<T>> SelectionOperator<T, S> for Tournam
 	}
 }
 
-struct StochasticUniversalSampling;
+pub struct StochasticUniversalSampling;
 
 impl<T: Chromosome, S: ChromosomeWrapper<T>> SelectionOperator<T, S> for StochasticUniversalSampling {
-	fn apply(&self, population: &Vec<S>, count: usize) -> Vec<&S> {
+	fn apply<'a> (&self, population: &'a Vec<S>, count: usize) -> Vec<&'a S> {
 		let total_fitness: f64 = population.into_iter()
 			.map(|indiv| indiv.get_fitness())
 			.sum();


### PR DESCRIPTION
## Description

Should be merged only after

* #74 

is merged.

So following up on [this comment](https://github.com/kkafar/evolutionary-algorithms/pull/71#issue-1445261313) I enclosed GA operators inside traits. Such approach allows for:

* Parameterization of operators
* Implementation overloading for different chromosome types
* Potentially having some internal mutable state inside operator

I've tried to use `Fn` / `FnMut` / `FnOnce` traits, but Rust [docs state that implementing it for custom structs is considered unstable](https://doc.rust-lang.org/stable/std/ops/trait.FnMut.html#required-methods), thus I went with `apply` method convention (inspired by Scala).

## Linked issues

N/A

## Important implementation details

I did not use any of `Fn*` traits, because it is reported that [implementing it for custom structs is unstable](https://doc.rust-lang.org/stable/std/ops/trait.Fn.html#required-methods). Thus I decided to go with `apply` method.
