### PR TITLE
chore: simplify issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -3,6 +3,8 @@ name: Bug report
 about: Use this template to report a bug
 ---
 
+<!-- If applicable - remeber to add the issue to the EA Rust project  -->
+
 ## Bug description
 
 

--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -3,9 +3,7 @@ name: Bug report
 about: Use this template to report a bug
 ---
 
-# Bug report
-
-## Description
+## Bug description
 
 
 ## Expected behaviour

--- a/.github/ISSUE_TEMPLATE/missing-feature.md
+++ b/.github/ISSUE_TEMPLATE/missing-feature.md
@@ -3,9 +3,7 @@ name: Feature proposal
 about: Use this template to propose new / missing features
 ---
 
-# Missing feature
-
-## Description
+## Feature description
 
 ## Motivation
 

--- a/.github/ISSUE_TEMPLATE/missing-feature.md
+++ b/.github/ISSUE_TEMPLATE/missing-feature.md
@@ -3,6 +3,8 @@ name: Feature proposal
 about: Use this template to propose new / missing features
 ---
 
+<!-- If applicable - remeber to add the issue to the EA Rust project  -->
+
 ## Feature description
 
 ## Motivation

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,10 +1,12 @@
+<!-- If applicable - remeber to add the PR to the EA Rust project (ONLY IF THERE IS NO LINKED ISSUE) -->
+
 ## Description
 
 <!-- Please describe the motivation & changes introduced by this PR -->
 
 ## Linked issues
 
-<!-- Please use "closes #<issue_no> syntax in case this PR should be linked to a PR -->
+<!-- Please use "Resolves #<issue_no> syntax in case this PR should be linked to an issue -->
 
 ## Important implementation details
 


### PR DESCRIPTION
## Description

I didn't like headers I previously add. Templates are more lean now.

Also added comments explaining when to add issue / PR to a project and when not to. 
